### PR TITLE
Implement error handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 #Minimum version of CMake to build this project
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8.12)
 
 # Declaration et nommage du projet
 project(parser)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,8 +4,9 @@ add_subdirectory(parse)
 
 # Add the binary and sources
 add_executable(
-  ../../parser
+  parser
   main.cc
 )
 
-target_link_libraries(../../parser parse)
+target_link_libraries(parser parse)
+set_target_properties(parser PROPERTIES RUNTIME_OUTPUT_DIRECTORY "../..")

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,10 +1,7 @@
 #include "parse/driver.hh"
 
-
 int main()
 {
     parse::Driver driver;
-    driver.parse();
-
-    return 0;
+    return driver.parse();
 }

--- a/src/parse/driver.cc
+++ b/src/parse/driver.cc
@@ -5,12 +5,12 @@
 namespace parse
 {
     Driver::Driver()
-        : scanner_ (new Scanner()),
-          parser_ (new Parser(*this)),
-          location_ (new location())
+        : scanner_(new Scanner()),
+          parser_(new Parser(*this)),
+          location_(new location()),
+          error_(0)
     {
     }
-
 
     Driver::~Driver()
     {
@@ -19,21 +19,21 @@ namespace parse
         delete location_;
     }
 
-
     void Driver::reset()
     {
         delete location_;
         location_ = new location();
+        error_ = 0;
     }
 
     int Driver::parse()
     {
         scanner_->switch_streams(&std::cin, &std::cerr);
         parser_->parse();
-        return 0;
+        return error_;
     }
 
-    int Driver::parse_file (std::string& path)
+    int Driver::parse_file(std::string &path)
     {
         std::ifstream s(path.c_str(), std::ifstream::in);
         scanner_->switch_streams(&s, &std::cerr);
@@ -42,6 +42,6 @@ namespace parse
 
         s.close();
 
-        return 0;
+        return error_;
     }
 }

--- a/src/parse/parse.yy
+++ b/src/parse/parse.yy
@@ -37,10 +37,10 @@
 %defines
 %debug
 %define api.namespace {parse}
-%define parser_class_name {Parser}
+%define api.parser.class {Parser}
 %parse-param {Driver &driver}
 %lex-param {Driver &driver}
-%error-verbose
+%define parse.error verbose
 
 %union
 {


### PR DESCRIPTION
This PR updates the parser so that the parsing methods return number of errors that occurred. Also the binary exists with the number of errors.

I also fixed some cmake and bison deprecation warnings.
On my machine I got `cmake 3.22.2` and `bison 3.8.2`.

I hope this helps to bring the template up-to-date. 😊