### PR TITLE
Move location tracking out of the driver

### DIFF
--- a/src/parse/driver.cc
+++ b/src/parse/driver.cc
@@ -7,7 +7,6 @@ namespace parse
     Driver::Driver()
         : scanner_(new Scanner()),
           parser_(new Parser(*this)),
-          location_(new location()),
           error_(0)
     {
     }
@@ -16,13 +15,10 @@ namespace parse
     {
         delete parser_;
         delete scanner_;
-        delete location_;
     }
 
     void Driver::reset()
     {
-        delete location_;
-        location_ = new location();
         error_ = 0;
     }
 

--- a/src/parse/driver.hh
+++ b/src/parse/driver.hh
@@ -27,7 +27,6 @@ namespace parse
         private:
             Scanner*      scanner_;
             Parser*       parser_;
-            location*     location_;
             int           error_;
 
             /// Allows Parser and Scanner to access private attributes

--- a/src/parse/parse.yy
+++ b/src/parse/parse.yy
@@ -65,9 +65,9 @@ start:
 
 namespace parse
 {
-    void Parser::error(const location&, const std::string& m)
+    void Parser::error(const location& l, const std::string& m)
     {
-        std::cerr << *driver.location_ << ": " << m << std::endl;
+        std::cerr << l << ": " << m << std::endl;
         driver.error_ = (driver.error_ == 127 ? 127 : driver.error_ + 1);
     }
 }

--- a/src/parse/scan.ll
+++ b/src/parse/scan.ll
@@ -9,18 +9,18 @@
 
 #define STEP()                                      \
   do {                                              \
-    driver.location_->step ();                      \
+    yylloc->step ();                      \
   } while (0)
 
-#define COL(Col)				                    \
-  driver.location_->columns (Col)
+#define COL(Col)				                            \
+  yylloc->columns (Col)
 
-#define LINE(Line)				                    \
-  do{						                        \
-    driver.location_->lines (Line);		            \
+#define LINE(Line)				                          \
+  do{						                                    \
+    yylloc->lines (Line);		              \
  } while (0)
 
-#define YY_USER_ACTION				                \
+#define YY_USER_ACTION				                      \
   COL(yyleng);
 
 
@@ -62,7 +62,7 @@ eol     [\n\r]+
 {eol}         LINE(yyleng);
 
 .             {
-                std::cerr << *driver.location_ << " Unexpected token : "
+                std::cerr << *yylloc << " Unexpected token : "
                                               << *yytext << std::endl;
                 driver.error_ = (driver.error_ == 127 ? 127
                                 : driver.error_ + 1);

--- a/src/parse/scanner.hh
+++ b/src/parse/scanner.hh
@@ -8,7 +8,7 @@
 # ifndef YY_DECL
 #  define YY_DECL parse::Parser::token_type                         \
      parse::Scanner::yylex(parse::Parser::semantic_type* yylval,    \
-                              parse::Parser::location_type*,        \
+                              parse::Parser::location_type* yylloc, \
                               parse::Driver& driver)
 # endif
 
@@ -31,7 +31,7 @@ namespace parse
 
             virtual Parser::token_type yylex(
                 Parser::semantic_type* yylval,
-                Parser::location_type* l,
+                Parser::location_type* yylloc,
                 Driver& driver);
 
             void set_debug(bool b);


### PR DESCRIPTION
This now let's us use the `@n` location actions in the parser to get the location of each token.

Bison calls `yylex` with a pointer to a location and expects the scanner to update the location. Before, this location was ignored and a separate location in the driver was used. However, bison wasn't aware of that and therefore the location actions pointed to bad locations.

I know that the template doesn't use the location actions in it's grammar, but it took me almost two days of research and debugging to get bison's location tracking to work and I think this would be nice to have in the template (also it's less code 😊).